### PR TITLE
Added maa.jwt.verifier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "maa.jwt.verifier/vendors/vcpkg"]
+	path = maa.jwt.verifier/vendors/vcpkg
+	url = git@github.com:microsoft/vcpkg.git

--- a/maa.jwt.verifier/.gitignore
+++ b/maa.jwt.verifier/.gitignore
@@ -1,0 +1,3 @@
+#Temporary Output Directories
+out
+tmp

--- a/maa.jwt.verifier/CMakeLists.txt
+++ b/maa.jwt.verifier/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+if(CMAKE_HOST_WIN32)
+    set(WINDOWS 1)
+elseif(CMAKE_HOST_UNIX)
+    set(LINUX 1)
+endif()
+
+if(WINDOWS)
+    set(VCPKG_TARGET_TRIPLET "x64-windows" CACHE STRING "")
+elseif(LUNUX)
+    set(VCPKG_TARGET_TRIPLET "x64-linux" CACHE STRING "")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(jwt-verifier LANGUAGES CXX)
+
+set(COMPONENT "OEHOSTVERIFY")
+
+set(SOURCES
+	${CMAKE_CURRENT_SOURCE_DIR}/src/base64.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/context.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/curl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/jwks.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/jwt.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/utils.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/x509.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
+)
+
+set(HEADERS
+	${CMAKE_CURRENT_SOURCE_DIR}/include/base64.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/context.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/curl.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/jwks.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/jwt.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/utils.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/x509.hpp
+)
+
+set(OPENSSL_USE_STATIC_LIBS TRUE)
+ 
+find_package(OpenEnclave CONFIG REQUIRED)
+find_package(OpenSSL REQUIRED)
+if(WINDOWS)
+    find_package(CURL CONFIG REQUIRED)
+endif()
+
+add_executable(jwt-verifier ${SOURCES} ${HEADERS})
+
+target_link_libraries(jwt-verifier PRIVATE openenclave::oehostverify)
+target_link_libraries(jwt-verifier PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
+if(WINDOWS)
+    target_link_libraries(jwt-verifier PRIVATE CURL::libcurl)
+    target_include_directories(jwt-verifier PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT jwt-verifier)
+    target_compile_options(jwt-verifier PRIVATE /W4 /WX)
+elseif(LINUX)
+    target_link_libraries(jwt-verifier PRIVATE curl)
+    target_include_directories(jwt-verifier PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_compile_options(jwt-verifier PRIVATE -Wall -Wextra -pedantic -Werror)
+endif()

--- a/maa.jwt.verifier/README.md
+++ b/maa.jwt.verifier/README.md
@@ -1,0 +1,136 @@
+## About
+
+JWT Verifier takes advantage of the Open Enclave SDK API call [oe_verify_attestation_certificate](https://openenclave.io/apidocs/v0.17/enclave_8h_a3b75c5638360adca181a0d945b45ad86.html#a3b75c5638360adca181a0d945b45ad86). See also https://openenclave.io/apidocs/v0.17/index.html .
+
+This function performs a custom validation on the input certificate. This validation includes extracting an attestation evidence extension from the certificate before validating this evidence.
+
+`jwt-verifier` builds and runs on Windows and Ubuntu Linux. The tool performs the following steps:
+- [ ] Parses MAA JWT;
+- [ ] Sends a request to MAA to get certificates;
+- [ ] Deserialize JSON Web Keys and finds x.509 certificates for the key;
+- [ ] Looks up for the MAA x509 extension;
+- [ ] Verifies the certificate using oe_verify_attestation_certificate OpenEnclave API.
+ 
+## Windows | Build and Run
+
+### Prerequisites
+- Dev System with Windows Server 2019
+- MAA JWT sample token as an input for the verification
+
+### Install Tools
+#### Optional Setup
+- `[Optional]` This step is needed if Internet Explorer is used for the file downloads **and** the `file download` option is disabled. In Internet Explorer, enable the `file download`:
+    - Open Internet Explorer;
+    - Click Tools and then Options;
+    - Click on the Security tab;
+    - Select the Internet Zone;
+    - Click on the Custom Level Button and then scroll down to Download;
+    - Make sure to enable File download;
+    - Click Apply and Ok;
+    - Restart Internet Explorer.
+
+#### Required Tools
+1. Download and install Git from https://git-scm.com/download/win
+2. Download and install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe)
+3. Download and install the latest stable CMake version [CMake v3.23.1](https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-windows-x86_64.msi). If the link does not work, see https://cmake.org/download/
+
+### Get Sources
+Open Git Bash:
+- `[Optional]` Setup the Git Bash with a new SSH key for the GitHub portal:
+    - Gegerate New SSH Key: `ssh-keygen -t ed25519 -C "<EMAIL>"`
+    - Go through the settings prompt and provide wanted values for the key
+    - `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519 && cat ~/.ssh/id_ed25519.pub`
+    - Add the new SSH key to the GitHub keys: https://github.com/settings/keys
+    - `git config --global user.email "you@example.com"`
+    - `git config --global user.name "Your Name"`
+
+- Clone the repo
+```
+git clone --recursive git@github.com:Azure-Samples/microsoft-azure-attestation.git
+```
+
+Or in GitBash or PowerShell:
+
+```
+git clone --recursive https://github.com/Azure-Samples/microsoft-azure-attestation.git
+```
+
+### Set up Environment and Run the Tool
+- In PowerShell, change the directory:
+```
+cd microsoft-azure-attestation\maa.jwt.verifier
+```
+
+- Execute the script win_setup_and_build.ps1 or, if desired, manually follow the script's steps:
+```
+.\win_setup_and_build.ps1
+```
+> These steps include installing the dependencies (nuget, vkpkg packages), creating the project via CMake, and building it.
+> Note that the intial execution of the script takes several minutes because it downloads and builds the dependencies.
+
+- Get your MAA JWT for verification to the system.
+- Change directory and run the tool:
+
+```
+cd <PATH-TO-EXE>
+.\jwt-verifier.exe <PATH-TO-JWT>\jwt.txt
+```
+
+The tool succeeded if returned:
+```
+---     SUCCESS - Verified attestation certificate quote
+```
+
+## Linux | Build and Run
+
+### Prerequisites
+- Dev System with Ubuntu_18.04
+- MAA JWT sample token as an input for the verification
+
+### Get Sources
+- `[Optional]` Setup the Git Bash with a new SSH key for the GirHub portal:
+    - Gegerate New SSH Key: `ssh-keygen -t ed25519 -C "<EMAIL>"`
+    - Go through the settings prompt and provide wanted values for the key
+    - `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519 && cat ~/.ssh/id_ed25519.pub`
+    - Add the new SSH key to the GitHub keys: https://github.com/settings/keys
+    - `git config --global user.email "you@example.com"`
+    - `git config --global user.name "Your Name"`
+
+- Clone the repo
+```
+git clone --recursive git@github.com:Azure-Samples/microsoft-azure-attestation.git
+```
+
+Or 
+
+```
+git clone --recursive https://github.com/Azure-Samples/microsoft-azure-attestation.git
+```
+
+### Set up Environment and Run the Tool
+- Change directory
+```
+cd microsoft-azure-attestation/maa.jwt.verifier
+```
+
+- Execute the script ubuntu_setup_and_build.sh or, if desired, manually follow the script's steps:
+```
+./ubuntu_setup_and_build.sh
+```
+
+- `[Optional]` Check the tool's usage syntax:
+```
+./out/jwt-verifier
+```
+
+- Get your MAA JWT for verification to the system.
+- Change directory and verify quote in JWT:
+```
+./out/jwt-verifier [options] <jwt-filename>
+```
+
+For instance:
+```
+./out/jwt-verifier -v ~/samples/jwt.txt
+```
+

--- a/maa.jwt.verifier/include/base64.hpp
+++ b/maa.jwt.verifier/include/base64.hpp
@@ -1,0 +1,26 @@
+/***************************************************************************************
+*    Title: Base64 encoding
+*    Author: Martin Vorbrodt
+*    Date: retrieved 12/06/2020
+*    Code version: commit 920f9265ff763e8a89c6ee6385162dd6aec3dbad
+*    Availability: https://github.com/mvorbrodt/blog/blob/master/src/base64.hpp
+*    Code samples from https://vorbrodt.blog/
+***************************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <cstdint>
+
+namespace base64
+{
+	inline static const char kEncodeLookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	inline static const char kPadCharacter = '=';
+
+	using byte = std::uint8_t;
+
+	std::string encode(const std::vector<byte>& input);
+	std::vector<byte> decode(const std::string& input);
+}

--- a/maa.jwt.verifier/include/context.hpp
+++ b/maa.jwt.verifier/include/context.hpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include <iostream>
 
-namespace mvj {
+namespace jwtverifier {
 
     class Context {
         bool is_verbose_;

--- a/maa.jwt.verifier/include/context.hpp
+++ b/maa.jwt.verifier/include/context.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+namespace mvj {
+
+    class Context {
+        bool is_verbose_;
+        std::string jwt_filename_;
+        Context();
+
+    public:
+
+        static Context& instance() {
+            static Context instance_;
+            return instance_;
+        }
+
+        template <typename T = std::string>
+        static void log(const T& v) {
+            if (Context::instance().is_verbose()) std::cout << v << std::endl;
+        }
+        static void always_log(const std::string& message);
+
+        void set(const std::vector<std::string>& args);
+        void dump() const;
+        bool is_verbose() const;
+        const std::string& get_jwt_filename() const;
+
+    private:
+        void set_verbose(const std::string& v);
+        void set_jwt_filename(const std::string& v);
+        void help_and_exit(const std::string& v = "");
+        void reset();
+    };
+}

--- a/maa.jwt.verifier/include/curl.hpp
+++ b/maa.jwt.verifier/include/curl.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <curl/curl.h>
+
+namespace mvj {
+
+    class Curl {
+        CURL* curl_;
+
+    public:
+        Curl();
+        ~Curl();
+        std::string get(const std::string& url, const std::string& headers = "");
+    };
+
+}

--- a/maa.jwt.verifier/include/curl.hpp
+++ b/maa.jwt.verifier/include/curl.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <curl/curl.h>
 
-namespace mvj {
+namespace jwtverifier {
 
     class Curl {
         CURL* curl_;

--- a/maa.jwt.verifier/include/jwks.hpp
+++ b/maa.jwt.verifier/include/jwks.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-namespace mvj {
+namespace jwtverifier {
 
     // Jwk struct wraps parameters of a JSON Web Key (JWK), received from MAA service.
     // JWK is a JavaScript Object Notation (JSON) data structure 

--- a/maa.jwt.verifier/include/jwks.hpp
+++ b/maa.jwt.verifier/include/jwks.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+namespace mvj {
+
+    // Jwk struct wraps parameters of a JSON Web Key (JWK), received from MAA service.
+    // JWK is a JavaScript Object Notation (JSON) data structure 
+    // that represents a cryptographic key.
+    // See the spec https://tools.ietf.org/html/rfc7517
+    struct Jwk {
+
+        // The "kid" (key ID) parameter is used to match a specific key.
+        // See section-4.5 of RFC7517 https://tools.ietf.org/html/rfc7517#section-4.5
+        std::string kid;
+        
+        // The "kty" (key type) parameter identifies the cryptographic 
+        // algorithm family used with the key, such as "RSA" or "EC".
+        // See section-4.1 of RFC7517 https://tools.ietf.org/html/rfc7517#section-4.1
+        std::string kty;
+
+        // The "x5c" (X.509 certificate chain) parameter contains a chain of one
+        //    or more PKIX certificates.
+        // See section-4.7 of RFC7517 https://tools.ietf.org/html/rfc7517#section-4.7
+        // See also X.509 spec RFC5280 https://tools.ietf.org/html/rfc5280
+        std::vector<std::string> x5c;
+        
+        Jwk() {}
+        explicit Jwk(const std::string& str);        
+    };
+
+    class Jwks {
+        std::unordered_map<std::string, Jwk> keys_;
+
+    public:
+        explicit Jwks(const std::string& keys_str);
+        bool get_certs(const std::string& key, std::vector<std::string>& certs) const;
+    };
+
+}

--- a/maa.jwt.verifier/include/jwt.hpp
+++ b/maa.jwt.verifier/include/jwt.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+
+namespace mvj {
+
+    class Jwt {
+        std::string encoded_token_;
+
+        std::string encoded_header_;
+        std::string encoded_payload_;
+        std::string encoded_signature_;
+
+        std::string decoded_header_;
+        std::string decoded_payload_;
+
+        std::string jku_;
+        std::string kid_;
+        std::string attest_dns_;
+        std::string tenant_;
+
+    public:
+        Jwt();
+        bool deserialize(const std::string& token);
+
+        std::string get_jku() const;
+        std::string get_tenant() const;
+        std::string get_kid() const;
+
+    private:
+        std::string parse_dns() const;
+        std::string parse_tenant() const;
+        std::string decode(const std::string& data) const;
+    };
+
+}

--- a/maa.jwt.verifier/include/jwt.hpp
+++ b/maa.jwt.verifier/include/jwt.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace mvj {
+namespace jwtverifier {
 
     class Jwt {
         std::string encoded_token_;

--- a/maa.jwt.verifier/include/utils.hpp
+++ b/maa.jwt.verifier/include/utils.hpp
@@ -3,18 +3,18 @@
 #include <string>
 #include <vector>
 
-namespace mvj::json {
+namespace jwtverifier::json {
     std::string get_value(const std::string& str, const std::string& key);    
     std::vector<std::string> get_array(const std::string& str, const std::string& key);
 }
 
-namespace mvj::strings {
+namespace jwtverifier::strings {
     void split(const std::string& str, const std::string& delim, std::vector<std::string>& result);
     void remove_char(std::string& str, char c);
     void remove_spaces(std::string& str);
     void tolower(std::string& in);
 }
 
-namespace mvj::file {
+namespace jwtverifier::file {
     bool get_lines(const std::string& filename, std::vector<std::string>& out);
 }

--- a/maa.jwt.verifier/include/utils.hpp
+++ b/maa.jwt.verifier/include/utils.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace mvj::json {
+    std::string get_value(const std::string& str, const std::string& key);    
+    std::vector<std::string> get_array(const std::string& str, const std::string& key);
+}
+
+namespace mvj::strings {
+    void split(const std::string& str, const std::string& delim, std::vector<std::string>& result);
+    void remove_char(std::string& str, char c);
+    void remove_spaces(std::string& str);
+    void tolower(std::string& in);
+}
+
+namespace mvj::file {
+    bool get_lines(const std::string& filename, std::vector<std::string>& out);
+}

--- a/maa.jwt.verifier/include/x509.hpp
+++ b/maa.jwt.verifier/include/x509.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <openssl/bio.h>
+#include <openssl/x509.h>
+
+namespace mvj {
+
+    using BIO_ptr = std::unique_ptr<BIO, decltype(&BIO_free)>;
+    using X509_ptr = std::unique_ptr<X509, decltype(&X509_free)>;
+    using ASN1_TIME_ptr = std::unique_ptr<ASN1_TIME, decltype(&ASN1_STRING_free)>;
+
+    class X509QuoteExt {
+        std::unordered_map< std::string, std::vector<uint8_t> > extensions_;
+
+    public:
+        X509QuoteExt();
+        explicit X509QuoteExt(const std::string& cert_content);
+        ~X509QuoteExt();
+
+        std::vector<uint8_t> find_extension(const std::string& extension_oid) const;
+        bool deserialize(const std::string& cert_content);
+
+    private:
+        void init();
+        void clear();
+        bool parse_extension(const STACK_OF(X509_EXTENSION) *exts, int n);
+    };
+}
+

--- a/maa.jwt.verifier/include/x509.hpp
+++ b/maa.jwt.verifier/include/x509.hpp
@@ -7,7 +7,7 @@
 #include <openssl/bio.h>
 #include <openssl/x509.h>
 
-namespace mvj {
+namespace jwtverifier {
 
     using BIO_ptr = std::unique_ptr<BIO, decltype(&BIO_free)>;
     using X509_ptr = std::unique_ptr<X509, decltype(&X509_free)>;

--- a/maa.jwt.verifier/src/base64.cpp
+++ b/maa.jwt.verifier/src/base64.cpp
@@ -1,0 +1,102 @@
+#include <base64.hpp>
+
+#include <context.hpp>
+
+namespace base64 {
+
+ 	std::string encode(const std::vector<byte>& input)
+	{
+		std::string encoded;
+		encoded.reserve(((input.size() / 3) + (input.size() % 3 > 0)) * 4);
+
+		std::uint32_t temp{};
+		auto it = input.begin();
+
+		for(std::size_t i = 0; i < input.size() / 3; ++i)
+		{
+			temp  = (*it++) << 16;
+			temp += (*it++) << 8;
+			temp += (*it++);
+			encoded.append(1, kEncodeLookup[(temp & 0x00FC0000) >> 18]);
+			encoded.append(1, kEncodeLookup[(temp & 0x0003F000) >> 12]);
+			encoded.append(1, kEncodeLookup[(temp & 0x00000FC0) >> 6 ]);
+			encoded.append(1, kEncodeLookup[(temp & 0x0000003F)      ]);
+		}
+
+		switch(input.size() % 3)
+		{
+		case 1:
+			temp = (*it++) << 16;
+			encoded.append(1, kEncodeLookup[(temp & 0x00FC0000) >> 18]);
+			encoded.append(1, kEncodeLookup[(temp & 0x0003F000) >> 12]);
+			encoded.append(2, kPadCharacter);
+			break;
+		case 2:
+			temp  = (*it++) << 16;
+			temp += (*it++) << 8;
+			encoded.append(1, kEncodeLookup[(temp & 0x00FC0000) >> 18]);
+			encoded.append(1, kEncodeLookup[(temp & 0x0003F000) >> 12]);
+			encoded.append(1, kEncodeLookup[(temp & 0x00000FC0) >> 6 ]);
+			encoded.append(1, kPadCharacter);
+			break;
+		}
+
+		return encoded;
+	}
+
+	std::vector<byte> decode(const std::string& input)
+	{
+		if(input.length() % 4)
+			throw std::runtime_error("Invalid base64 length!");
+
+		std::size_t padding{};
+
+		if(input.length())
+		{
+			if(input[input.length() - 1] == kPadCharacter) padding++;
+			if(input[input.length() - 2] == kPadCharacter) padding++;
+		}
+
+		std::vector<byte> decoded;
+		decoded.reserve(((input.length() / 4) * 3) - padding);
+
+		std::uint32_t temp{};
+		auto it = input.begin();
+
+		while(it < input.end())
+		{
+			for(std::size_t i = 0; i < 4; ++i)
+			{
+				temp <<= 6;
+				if (*it >= 0x41 && *it <= 0x5A) temp |= *it - 0x41;
+				else if (*it >= 0x61 && *it <= 0x7A) temp |= *it - 0x47;
+				else if (*it >= 0x30 && *it <= 0x39) temp |= *it + 0x04;
+				else if (*it == 0x2B)                temp |= 0x3E;
+				else if (*it == 0x2F)                temp |= 0x3F;
+				else if (*it == kPadCharacter)
+				{
+					switch (input.end() - it)
+					{
+					case 1:
+						decoded.push_back((temp >> 16) & 0x000000FF);
+						decoded.push_back((temp >> 8) & 0x000000FF);
+						return decoded;
+					case 2:
+						decoded.push_back((temp >> 10) & 0x000000FF);
+						return decoded;
+					default:
+						throw std::runtime_error("Invalid padding in base64!");
+					}
+				}
+				else throw std::runtime_error("Invalid character in base64!");
+				++it;
+			}
+
+			decoded.push_back((temp >> 16) & 0x000000FF);
+			decoded.push_back((temp >> 8 ) & 0x000000FF);
+			decoded.push_back((temp      ) & 0x000000FF);
+		}
+
+		return decoded;
+	}
+}

--- a/maa.jwt.verifier/src/context.cpp
+++ b/maa.jwt.verifier/src/context.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <unordered_map>
 
-namespace mvj {
+namespace jwtverifier {
 
     typedef void (Context::* ContextMemFn)(const std::string&);
 

--- a/maa.jwt.verifier/src/context.cpp
+++ b/maa.jwt.verifier/src/context.cpp
@@ -1,0 +1,82 @@
+#include <context.hpp>
+#include <utils.hpp>
+
+#include <functional>
+#include <chrono>
+#include <unordered_map>
+
+namespace mvj {
+
+    typedef void (Context::* ContextMemFn)(const std::string&);
+
+    Context::Context() {
+        this->is_verbose_ = false;
+        this->jwt_filename_ = "";
+    }
+
+    void Context::always_log(const std::string& message) {
+        std::cout << "---\t" << message << std::endl;
+    }
+
+    void Context::set(const std::vector<std::string>& args) {
+        const size_t sz = args.size();
+        if (sz < 2) {
+            this->help_and_exit();
+        }
+
+        this->reset();
+        const std::unordered_map<std::string, ContextMemFn> opt_setters({
+            {"-v", &Context::set_verbose},
+            {"--verbose", &Context::set_verbose},
+            {"-h", &Context::help_and_exit},
+            {"--help", &Context::help_and_exit}
+        });
+
+        for (size_t i = 1; i < sz; ++i) {
+            std::string arg = args[i];
+            strings::tolower(arg);
+
+            auto opt_it = opt_setters.find(arg);
+            if (opt_it != opt_setters.end()) {
+                std::invoke(opt_it->second, this, "");
+                continue;
+            }
+
+            if (this->jwt_filename_.empty()) {
+                this->jwt_filename_ = args[i];
+                continue;
+            }
+
+            this->help_and_exit();
+        }
+    }
+
+    void Context::dump() const {
+        if (this->is_verbose_) {
+            std::cout << std::endl << "Arguments for this run:" << std::endl;
+            std::cout << '\t' << "jwt_filename " << '\t' << ":" << '\t' << this->jwt_filename_ << std::endl;
+        }
+    }
+
+    bool Context::is_verbose() const { return this->is_verbose_; }
+    const std::string& Context::get_jwt_filename() const { return this->jwt_filename_; }
+
+    void Context::set_verbose(const std::string&) { this->is_verbose_ = true; }
+    void Context::set_jwt_filename(const std::string& v) { this->jwt_filename_ = v; }
+
+    void Context::help_and_exit(const std::string&) {
+        std::cout << std::endl;
+        std::cout << "Usage: jwt_varifier [options] file" << std::endl;
+        std::cout << std::endl;
+        std::cout << "Arguments:" << std::endl;
+        std::cout << "    -v or --verbose          Include verbose messages" << std::endl;
+        std::cout << "    -h or --help             Print Help (this message) and exit" << std::endl;
+        std::cout << std::endl;
+        exit(EXIT_SUCCESS);
+    }
+
+    void Context::reset() {
+        this->is_verbose_ = false;
+        this->jwt_filename_.clear();
+    }
+}

--- a/maa.jwt.verifier/src/curl.cpp
+++ b/maa.jwt.verifier/src/curl.cpp
@@ -1,0 +1,92 @@
+#include <curl.hpp>
+
+#include <context.hpp>
+#include <cstdlib>
+#include <cstring>
+
+namespace mvj {
+    
+    struct MemoryChunk {
+        char* memory;
+        size_t size;
+        MemoryChunk() {
+            memory = (char*)malloc(1); // will be grown as needed by the realloc above
+            size = 0; // no data at this point
+        }
+        ~MemoryChunk() {
+            free(memory);
+        }
+    };
+
+    static size_t write_cb(void* contents, size_t size, size_t nmemb, void* userp) {
+        size_t realsize = size * nmemb;
+        struct MemoryChunk* mem = (struct MemoryChunk*)userp;
+        char* ptr = (char*)realloc(mem->memory, mem->size + realsize + 1);
+        if (ptr == nullptr) {
+            Context::log("Failed to allocate memory, realloc returned NULL, not enough memory");
+            return 0;
+        }
+        mem->memory = ptr;
+        memcpy(&(mem->memory[mem->size]), contents, realsize);
+        mem->size += realsize;
+        mem->memory[mem->size] = 0;
+        return realsize;
+    }
+
+    Curl::Curl(): curl_(nullptr) {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+    }
+
+    Curl::~Curl() {
+        curl_global_cleanup();
+    }
+
+    std::string Curl::get(const std::string& url, const std::string& headers) {
+        if (url.empty()) {
+            Context::log("Failed to send get request, input url is empty");
+            return "";
+        }
+        if (curl_ != nullptr) {
+            curl_easy_cleanup(curl_);
+            curl_ = nullptr;
+        }
+
+        MemoryChunk chunk;
+        curl_ = curl_easy_init();
+        std::string response = "";
+        if (curl_ != nullptr) {
+            curl_easy_setopt(curl_, CURLOPT_URL, url.c_str());
+            
+            // Headers 
+            struct curl_slist* header_list = nullptr;
+            if (!headers.empty()) {
+                header_list = curl_slist_append(header_list, headers.c_str());
+                curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, header_list);
+            }
+
+            // Verbose
+            if (Context::instance().is_verbose()) {
+                curl_easy_setopt(curl_, CURLOPT_VERBOSE, 1L);
+            }
+
+            // Options
+            curl_easy_setopt(curl_, CURLOPT_FOLLOWLOCATION, 1L); // [required] follow HTTP 3xx redirects
+            curl_easy_setopt(curl_, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2); // [required] MAA supports only TLSv1.2
+            curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 0L); // [per system] Do not verify the peer's SSL certificate
+            curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION, write_cb); // [required] send all data to this function
+            curl_easy_setopt(curl_, CURLOPT_WRITEDATA, (void*)&chunk); // [required] we pass our 'chunk' struct to the callback function
+
+            CURLcode res = curl_easy_perform(curl_);
+            if (CURLE_OK != res) {
+                Context::log("curl_easy_perform() failed: " + std::string(curl_easy_strerror(res)));
+            }
+            else {
+                Context::log("Received " + std::to_string(chunk.size) + " bytes");
+                response = std::string(chunk.memory);
+            }
+            curl_easy_cleanup(curl_);
+            curl_slist_free_all(header_list);
+        }
+        return response;
+    }
+}

--- a/maa.jwt.verifier/src/curl.cpp
+++ b/maa.jwt.verifier/src/curl.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace mvj {
+namespace jwtverifier {
     
     struct MemoryChunk {
         char* memory;

--- a/maa.jwt.verifier/src/jwks.cpp
+++ b/maa.jwt.verifier/src/jwks.cpp
@@ -4,7 +4,7 @@
 #include <context.hpp>
 #include <regex>
 
-namespace mvj {
+namespace jwtverifier {
 
     Jwk::Jwk(const std::string& str) : kid(), kty(), x5c() {
         kid = json::get_value(str, "kid");
@@ -14,7 +14,7 @@ namespace mvj {
 
     Jwks::Jwks(const std::string& str) {
         std::vector<std::string> raw_keys;
-        mvj::strings::split(str, "\\}[ \n\r]*,", raw_keys);
+        jwtverifier::strings::split(str, "\\}[ \n\r]*,", raw_keys);
         for (auto raw_key : raw_keys) {
             Jwk key(raw_key);
             keys_[key.kid] = key;

--- a/maa.jwt.verifier/src/jwks.cpp
+++ b/maa.jwt.verifier/src/jwks.cpp
@@ -1,0 +1,37 @@
+#include <jwks.hpp>
+
+#include <utils.hpp>
+#include <context.hpp>
+#include <regex>
+
+namespace mvj {
+
+    Jwk::Jwk(const std::string& str) : kid(), kty(), x5c() {
+        kid = json::get_value(str, "kid");
+        kty = json::get_value(str, "kty");
+        x5c = json::get_array(str, "x5c");
+    }
+
+    Jwks::Jwks(const std::string& str) {
+        std::vector<std::string> raw_keys;
+        mvj::strings::split(str, "\\}[ \n\r]*,", raw_keys);
+        for (auto raw_key : raw_keys) {
+            Jwk key(raw_key);
+            keys_[key.kid] = key;
+        }
+    }
+    
+    bool Jwks::get_certs(const std::string& key, std::vector<std::string>& certs) const {
+        certs.clear();
+        auto it = keys_.find(key);
+        if (it != keys_.end()) {
+            certs = it->second.x5c;
+            return true;
+        }
+        else {
+            Context::log("Could not find key: " + key);
+            return false;
+        }
+    }
+
+}

--- a/maa.jwt.verifier/src/jwt.cpp
+++ b/maa.jwt.verifier/src/jwt.cpp
@@ -1,0 +1,73 @@
+#include <jwt.hpp>
+
+#include <utils.hpp>
+#include <context.hpp>
+#include <base64.hpp>
+#include <regex>
+
+namespace mvj {
+
+    Jwt::Jwt() {}
+        
+    bool Jwt::deserialize(const std::string& token) {
+        try {
+            encoded_token_ = token;
+            std::vector<std::string> hps; 
+            strings::split(token, "\\.", hps);
+    
+            if (hps.size() != 3) {
+                throw std::runtime_error("Invalid token!");
+            }
+            encoded_header_ = hps[0];
+            encoded_payload_ = hps[1];
+            encoded_signature_ = hps[2];
+    
+            decoded_header_ = decode(encoded_header_);
+            decoded_payload_ = decode(encoded_payload_);
+    
+            jku_ = json::get_value(decoded_header_, "jku");
+            kid_ = json::get_value(decoded_header_, "kid");
+            attest_dns_ = parse_dns();
+            tenant_ = parse_tenant();
+        }
+        catch (const char* ex) {
+            Context::log("Failed to deserialize JWT, exception: " + std::string(ex));
+            return false;
+        }
+        return true;
+    }
+
+    std::string Jwt::get_jku() const { return jku_; }
+    std::string Jwt::get_tenant() const { return (tenant_.size() > 24) ? tenant_.substr(0, 24) : tenant_; }
+    std::string Jwt::get_kid() const { return kid_; }
+
+    std::string Jwt::parse_dns() const {
+        if (decoded_header_.empty()) {
+            Context::log("Empty decoded JWT header, cannot retrieve attest DNS");
+            return "";
+        }
+        std::regex rgx("https://([0-9a-zA-Z.]*)");
+        std::smatch match;
+        std::string result = (std::regex_search(decoded_header_.begin(), decoded_header_.end(), match, rgx)) ? std::string(match[1]) : "";
+        return result;
+    }
+
+    std::string Jwt::parse_tenant() const {
+        if (attest_dns_.empty()) {
+            Context::log("Empty attest DNS, cannot retrieve tenant name");
+            return "";
+        }
+        std::string result = attest_dns_.substr(0, attest_dns_.find_first_of("."));
+        return result;
+    }
+
+    std::string Jwt::decode(const std::string& data) const {
+        std::string uri_dec(data);
+        const size_t sz = data.size();
+        const size_t padding = 4 * static_cast<size_t>(sz % 4 != 0) - (sz % 4);
+        uri_dec.resize(sz + padding, '=');
+        auto decoded = base64::decode(uri_dec);
+        std::string decoded_str(decoded.begin(), decoded.end());
+        return decoded_str;
+    }
+}

--- a/maa.jwt.verifier/src/jwt.cpp
+++ b/maa.jwt.verifier/src/jwt.cpp
@@ -5,7 +5,7 @@
 #include <base64.hpp>
 #include <regex>
 
-namespace mvj {
+namespace jwtverifier {
 
     Jwt::Jwt() {}
         

--- a/maa.jwt.verifier/src/jwt.cpp
+++ b/maa.jwt.verifier/src/jwt.cpp
@@ -30,8 +30,16 @@ namespace jwtverifier {
             attest_dns_ = parse_dns();
             tenant_ = parse_tenant();
         }
-        catch (const char* ex) {
-            Context::log("Failed to deserialize JWT, exception: " + std::string(ex));
+        catch (const std::exception& ex) {
+            Context::log("Failed to deserialize JWT, exception: " + std::string(ex.what()));
+            return false;
+        }
+        catch (const std::string& ex) {
+            Context::log("Failed to deserialize JWT, exception: " + ex);
+            return false;
+        }
+        catch (...) {
+            Context::log("Failed to deserialize JWT");
             return false;
         }
         return true;

--- a/maa.jwt.verifier/src/jwt.cpp
+++ b/maa.jwt.verifier/src/jwt.cpp
@@ -46,7 +46,7 @@ namespace jwtverifier {
     }
 
     std::string Jwt::get_jku() const { return jku_; }
-    std::string Jwt::get_tenant() const { return (tenant_.size() > 24) ? tenant_.substr(0, 24) : tenant_; }
+    std::string Jwt::get_tenant() const { return tenant_; }
     std::string Jwt::get_kid() const { return kid_; }
 
     std::string Jwt::parse_dns() const {

--- a/maa.jwt.verifier/src/main.cpp
+++ b/maa.jwt.verifier/src/main.cpp
@@ -1,0 +1,116 @@
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+
+#include <context.hpp>
+#include <utils.hpp>
+#include <jwt.hpp>
+#include <jwks.hpp>
+#include <curl.hpp>
+#include <x509.hpp>
+#include <base64.hpp>
+
+#include <openenclave/host_verify.h>
+#include <openenclave/attestation/verifier.h>
+#include <openenclave/attestation/sgx/evidence.h>
+
+using namespace mvj;
+
+uint32_t    _id_version;
+uint64_t    _attributes;
+uint32_t    _security_version;
+std::string _unique_id;
+std::string _signer_id;
+std::string _product_id;
+
+std::string uint8_to_hex_string(const uint8_t *v, const size_t s) {
+      std::stringstream ss;
+      ss << std::hex << std::setfill('0');
+      for (size_t i = 0; i < s; ss << std::hex << std::setw(2) << static_cast<int>(v[i++]));
+      return ss.str();
+}
+
+oe_result_t enclave_identity_verifier(oe_identity_t* identity, void*)
+{
+    _attributes = identity->attributes;
+    _id_version = identity->id_version;
+    _security_version = identity->security_version;
+
+    _unique_id = uint8_to_hex_string(identity->unique_id, OE_UNIQUE_ID_SIZE);
+    _signer_id = uint8_to_hex_string(identity->signer_id, OE_SIGNER_ID_SIZE);
+    _product_id = uint8_to_hex_string(identity->product_id, OE_PRODUCT_ID_SIZE);
+    return OE_OK;
+}
+
+int main(int argc, char* argv[]) {
+    std::vector<std::string> argvec(argc, "");
+    for (int count = 0; count < argc; count++) argvec[count] = argv[count];
+
+    // Parse arguments.
+    Context::instance().set(argvec);
+
+    // Read JWT from file.
+    std::vector<std::string> str_tokens;
+    if (!file::get_lines(Context::instance().get_jwt_filename(), str_tokens)) {
+        Context::always_log("ERROR - Failed to read input file");
+        return EXIT_FAILURE;
+    }
+
+    // Deserialize JWT.
+    Jwt jwt;
+    if (!jwt.deserialize(str_tokens[0])) {
+        Context::always_log("ERROR - Failed to deserialize JWT token");
+        return EXIT_FAILURE;
+    }
+
+    // Send request to MAA to get certficates.
+    Curl curl;
+    std::string response = curl.get(jwt.get_jku());
+    if (response.empty()) {
+        Context::always_log("ERROR - Failed to retrieve certificates");
+        return EXIT_FAILURE;
+    }
+
+    // Deserialize JSON Web Keys and find x.509 certificates for the key.
+    Jwks jwks(response);
+    std::vector<std::string> certs;
+    if (!jwks.get_certs(jwt.get_kid(), certs)) {
+        Context::always_log("ERROR - Failed to find x509 certificates for the key");
+        return EXIT_FAILURE;
+    }
+
+    // X.509.
+    X509QuoteExt x509(certs[0]);
+    auto quote_ext = x509.find_extension("1.3.6.1.4.1.311.105.1");
+    if (quote_ext.empty()) {
+        Context::always_log("ERROR - Failed to find wanted quote extension");
+        return EXIT_FAILURE;
+    }
+
+    // Verify the certificate.
+    auto cert = certs[0];
+    auto decoded_cert = base64::decode(cert);
+    auto rv = oe_verify_attestation_certificate(decoded_cert.data(), decoded_cert.size(), enclave_identity_verifier, nullptr);
+    if (rv != OE_OK) {
+        Context::always_log("ERROR - Failed to verify attestation certificate");
+    } else {
+        Context::always_log("SUCCESS - Verified attestation certificate quote");
+        Context::log("id_version:");
+        Context::log(_id_version);
+        Context::log("attributes:");
+        Context::log(_attributes);
+        Context::log("security_version:");
+        Context::log(_security_version);
+        Context::log("unique_id:");
+        Context::log(_unique_id);
+        Context::log("signer_id:");
+        Context::log(_signer_id);
+        Context::log("product_id:");
+        Context::log(_product_id);
+    }
+    
+    return EXIT_SUCCESS;
+}

--- a/maa.jwt.verifier/src/main.cpp
+++ b/maa.jwt.verifier/src/main.cpp
@@ -17,7 +17,7 @@
 #include <openenclave/attestation/verifier.h>
 #include <openenclave/attestation/sgx/evidence.h>
 
-using namespace mvj;
+using namespace jwtverifier;
 
 uint32_t    _id_version;
 uint64_t    _attributes;

--- a/maa.jwt.verifier/src/utils.cpp
+++ b/maa.jwt.verifier/src/utils.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <fstream>
 
-namespace mvj::json {
+namespace jwtverifier::json {
 
     std::string get_value(const std::string& str, const std::string& key) {
         if (str.empty()) {
@@ -28,12 +28,12 @@ namespace mvj::json {
         std::string values = (std::regex_search(str.begin(), str.end(), match, rgx)) ? std::string(match[1]) : "";
         strings::remove_char(values, '"');
         std::vector<std::string> result;
-        mvj::strings::split(values, ",", result);
+        jwtverifier::strings::split(values, ",", result);
         return result;
     }
 }
 
-namespace mvj::strings {
+namespace jwtverifier::strings {
 
     void split(const std::string& str, const std::string& delim, std::vector<std::string>& result) {
         std::regex regex(delim);
@@ -54,7 +54,7 @@ namespace mvj::strings {
 
 }
 
-namespace mvj::file {
+namespace jwtverifier::file {
     bool get_lines(const std::string& filename, std::vector<std::string>& out) {
         if (filename.empty()) {
             Context::log("Faile name is empty, exiting");

--- a/maa.jwt.verifier/src/utils.cpp
+++ b/maa.jwt.verifier/src/utils.cpp
@@ -1,0 +1,85 @@
+#include <utils.hpp>
+
+#include <context.hpp>
+#include <regex>
+#include <iostream>
+#include <fstream>
+
+namespace mvj::json {
+
+    std::string get_value(const std::string& str, const std::string& key) {
+        if (str.empty()) {
+            Context::log("Input string is empty, cannot get value for key " + key);
+            return "";
+        }
+        std::regex rgx(".*" + key + "[ \n\r]*\"[ \n\r]*:[ \n\r]*\"[ \n\r]*([^\"]*)");
+        std::smatch match;
+        std::string result = (std::regex_search(str.begin(), str.end(), match, rgx)) ? std::string(match[1]) : "";
+        return result;
+    }
+
+    std::vector<std::string> get_array(const std::string& str, const std::string& key) {
+        if (str.empty()) {
+            Context::log("Input string is empty, cannot get array of value for key " + key);
+            return std::vector<std::string>();
+        }
+        std::regex rgx(".*" + key + "[ \n\r]*\"[ \n\r]*:[ \n\r]*[[ \n\r]*([^\\]]*)");
+        std::smatch match;
+        std::string values = (std::regex_search(str.begin(), str.end(), match, rgx)) ? std::string(match[1]) : "";
+        strings::remove_char(values, '"');
+        std::vector<std::string> result;
+        mvj::strings::split(values, ",", result);
+        return result;
+    }
+}
+
+namespace mvj::strings {
+
+    void split(const std::string& str, const std::string& delim, std::vector<std::string>& result) {
+        std::regex regex(delim);
+        result = std::vector<std::string>(std::sregex_token_iterator(str.begin(), str.end(), regex, -1), std::sregex_token_iterator());
+    }
+
+    void remove_char(std::string& str, char c) {
+        str.erase(std::remove(str.begin(), str.end(), c), str.end());
+    }
+
+    void remove_spaces(std::string& str) {
+        str.erase(remove_if(str.begin(), str.end(), isspace), str.end());
+    }
+
+    void tolower(std::string& in) {
+        std::transform(in.begin(), in.end(), in.begin(), [](int c) { return static_cast<char>(std::tolower(c)); });
+    }
+
+}
+
+namespace mvj::file {
+    bool get_lines(const std::string& filename, std::vector<std::string>& out) {
+        if (filename.empty()) {
+            Context::log("Faile name is empty, exiting");
+            return false;
+        }
+        out.clear();
+        std::ifstream infile;
+        infile.open(filename);
+        if (infile) {
+            while (!infile.eof())
+            {
+                std::string line;
+                getline(infile, line);
+                out.push_back(line);
+            }
+            infile.close();
+            if (out.empty()) {
+                Context::log("Could not find any record in file: " + filename);
+                return false;
+            }
+        }
+        else {
+            Context::log("Failed to open file: " + filename);
+            return false;
+        }
+        return true;
+    }
+}

--- a/maa.jwt.verifier/src/x509.cpp
+++ b/maa.jwt.verifier/src/x509.cpp
@@ -12,7 +12,7 @@
 
 #include <context.hpp>
 
-namespace mvj {
+namespace jwtverifier {
 
     void X509QuoteExt::init() {
         // Adds all algorithms to the table (digests and ciphers).

--- a/maa.jwt.verifier/src/x509.cpp
+++ b/maa.jwt.verifier/src/x509.cpp
@@ -76,10 +76,9 @@ namespace jwtverifier {
             return false;
         }
 
-        // Magic number 80 is a constance used within OpenSSL library.
-        // See: https://git.happyzh.com/github/openssl/-/blob/master/crypto/asn1/a_object.c#L187
-        const int sz = 80;
-        char obj_buffer[sz];
+        // 80 is a constant used by OpenSSL Crypto (see https://github.com/openssl/openssl/blob/master/crypto/asn1/a_object.c)
+	const int sz = 80;
+	char obj_buffer[sz];
         memset(obj_buffer, 0, sz);
         BIO_read(output_bio.get(), obj_buffer, sz - 1);
         std::string ext_string(obj_buffer);

--- a/maa.jwt.verifier/src/x509.cpp
+++ b/maa.jwt.verifier/src/x509.cpp
@@ -1,0 +1,144 @@
+#include <x509.hpp>
+
+#include <iostream>
+#include <vector>
+#include <cstring>
+#include <algorithm>
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/x509v3.h>
+#include <openssl/ts.h>
+
+#include <context.hpp>
+
+namespace mvj {
+
+    void X509QuoteExt::init() {
+        // Adds all algorithms to the table (digests and ciphers).
+        // In versions prior to 1.1.0 EVP_cleanup() removed all ciphers and digests from the table.
+        // It no longer has any effect in OpenSSL 1.1.0.
+        OpenSSL_add_all_algorithms();
+
+        // ERR_load_crypto_strings() Registers the error strings for all libcrypto functions.
+        // ERR_free_strings() frees all previously loaded error strings.
+        ERR_load_crypto_strings();
+
+        // Disables configuration. If called before OPENSSL_config() no configuration takes place.
+        OPENSSL_no_config();
+    }
+
+
+    X509QuoteExt::X509QuoteExt() {
+    }
+
+    X509QuoteExt::X509QuoteExt(const std::string& cert_str) {
+        if (!this->deserialize(cert_str)) {
+            Context::always_log("ERROR - Failed to deserialize x509 cert");
+        }
+    }
+
+    X509QuoteExt::~X509QuoteExt() {
+        clear();
+    }
+
+    std::vector<uint8_t> X509QuoteExt::find_extension(const std::string& extension_oid) const {
+        std::vector<uint8_t> res;
+        auto it = this->extensions_.find(extension_oid);
+        if (it != this->extensions_.end()) {
+            res = it->second;
+        }
+        return res;
+    }
+
+    void output_certificate(const uint8_t* data, size_t data_len)
+    {
+        X509* x509;
+        BIO* input = BIO_new_mem_buf(data, (int)data_len);
+        x509 = d2i_X509_bio(input, nullptr);
+        if (x509)
+            X509_print_ex_fp(
+                stdout,
+                x509,
+                XN_FLAG_COMPAT,
+                XN_FLAG_SEP_CPLUS_SPC | XN_FLAG_DUMP_UNKNOWN_FIELDS);
+        BIO_free_all(input);
+    }
+
+    bool X509QuoteExt::parse_extension(const STACK_OF(X509_EXTENSION) *exts, int n) {
+        // Create a BIO to hold info from the cert.
+        BIO_ptr output_bio(BIO_new(BIO_s_mem()), BIO_free);
+
+        X509_EXTENSION *ex = X509v3_get_ext(exts, n);
+        ASN1_OBJECT *obj = X509_EXTENSION_get_object(ex);
+        if (i2a_ASN1_OBJECT(output_bio.get(), obj) < 0) {
+            Context::log("Failed to write X509 extension into BIO, extension # " + std::to_string(n));
+            return false;
+        }
+
+        // Magic number 80 is a constance used within OpenSSL library.
+        // See: https://git.happyzh.com/github/openssl/-/blob/master/crypto/asn1/a_object.c#L187
+        const int sz = 80;
+        char obj_buffer[sz];
+        memset(obj_buffer, 0, sz);
+        BIO_read(output_bio.get(), obj_buffer, sz - 1);
+        std::string ext_string(obj_buffer);
+
+        BIO_reset(output_bio.get());
+        if (!X509V3_EXT_print(output_bio.get(), ex, 0, 0)) {
+            ASN1_STRING_print(output_bio.get(), X509_EXTENSION_get_data(ex));
+        }
+        const int large_sz = 32768;
+        char value_buffer[large_sz];
+        memset(value_buffer, 0, large_sz);
+        BIO_read(output_bio.get(), value_buffer, large_sz - 1);
+        std::vector<uint8_t> value(large_sz);
+        std::transform(value_buffer, value_buffer + large_sz, value.begin(), [](char v) {return static_cast<uint8_t>(v);});
+
+        this->extensions_.insert({ext_string, value});
+        return true;
+    }
+
+    bool X509QuoteExt::deserialize(const std::string& cert_str) {
+        clear();
+        init();
+
+        Context::log("Raw cert string value:");
+        Context::log(cert_str);
+
+        std::string cert_content = "-----BEGIN CERTIFICATE-----\n" + cert_str + "\n-----END CERTIFICATE-----";
+        output_certificate(reinterpret_cast<const uint8_t*>(&cert_content[0]), cert_content.size());
+        
+        // Put the certificate contents into an openssl IO stream (BIO)
+        BIO_ptr bio = BIO_ptr(BIO_new(BIO_s_mem()), BIO_free);
+        BIO_write(bio.get(), cert_content.c_str(), (int)cert_content.size());
+
+        // Create an openssl certificate from the BIO
+        X509_ptr cert(PEM_read_bio_X509_AUX(bio.get(), NULL, NULL, NULL), X509_free);
+
+        const STACK_OF(X509_EXTENSION) *exts = X509_get0_extensions(cert.get());
+        const int ext_count = X509_get_ext_count(cert.get());
+        for (int i = 0; i < ext_count; ++i) {
+            if (!parse_extension(exts, i)) {
+                Context::log("Failed to deserialize one of the extensions");
+                return false;
+            }
+        }
+
+        for (auto ext: this->extensions_) {
+            Context::log(ext.first);
+            std::string ext_value(ext.second.begin(), ext.second.end());
+            Context::log(ext_value);
+            Context::log("========================================");
+        }
+        return true;
+    }
+
+    void X509QuoteExt::clear() {
+        CONF_modules_unload(1);
+        CONF_modules_free();
+        ERR_free_strings();
+        EVP_cleanup();
+        CRYPTO_cleanup_all_ex_data(); // CRYPTO_cleanup_all_ex_data and ERR_remove_state should be called on each thread, and not just the main thread.
+    }
+}

--- a/maa.jwt.verifier/ubuntu_setup_and_build.sh
+++ b/maa.jwt.verifier/ubuntu_setup_and_build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset   
+# do not hide errors within pipes
+set -o pipefail  
+
+function __msg() {
+    echo -e "    $*"
+}
+
+function __msg_stage() {
+    echo -e "********************************************************************"
+    echo -e "*   $*"
+    echo -e "********************************************************************"
+}
+
+__msg_stage "Setup Environment"
+
+__msg_stage "Update and Upgrade System"
+sudo apt update && sudo apt -y upgrade
+
+__msg_stage "Configure the Intel and Microsoft APT Repositories"
+# This step and the next one below are based on the Open Enclave's documentation with a few adjustments.
+# See: https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/install_host_verify_Ubuntu_18.04.md
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+__msg_stage "Install the Intel and Open Enclave Host-Verify packages and dependencies"
+# This step also installs the az-dcap-client package which is necessary for performing remote attestation in Azure.
+# A general implementation for using Intel DCAP outside the Azure environment is coming soon.
+# https://github.com/microsoft/azure-dcap-client
+sudo apt update
+sudo apt -y install make cmake g++ libssl-dev libcurl4-openssl-dev libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave-hostverify
+
+__msg_stage "Read and execute the content of openenclaverc"
+# This step is needed for pkg-config oehostverify-$(CXX) ... command to function properly.
+echo "source /opt/openenclave/share/openenclave/openenclaverc" >> ~/.bashrc
+# This step is needed for supressing the WARNING (it is not an error, it is a warning!) message:
+# Azure Quote Provider: libdcap_quoteprov.so [ERROR]: Could not retrieve environment variable for 'AZDCAP_DEBUG_LOG_LEVEL'
+echo 'export AZDCAP_DEBUG_LOG_LEVEL=None' >> ~/.bashrc
+source ~/.bashrc
+
+__msg_stage "Build"
+
+rm -rvf ./out
+mkdir -pv out
+export LOCAL_ROOT="$(dirname $(pwd))"
+echo $LOCAL_ROOT
+cd out/
+cmake ../
+make
+
+./jwt-verifier
+

--- a/maa.jwt.verifier/win_setup_and_build.ps1
+++ b/maa.jwt.verifier/win_setup_and_build.ps1
@@ -1,0 +1,110 @@
+# Update Submodules
+#
+git submodule update --init --recursive
+
+# Define Local Directories
+#
+$cur_dir=Get-Location
+$tmp_pkg_dir = "$cur_dir\tmp"
+
+If((Test-Path $tmp_pkg_dir))
+{
+    Remove-Item $tmp_pkg_dir -Force -Recurse
+}
+New-Item -ItemType Directory -Force -Path $tmp_pkg_dir
+
+# Download Nuget Tool
+#
+$nuget_file_name = "nuget.exe"
+$nuget_source = "https://dist.nuget.org/win-x86-commandline/latest/$nuget_file_name"
+$nuget_destination = "$tmp_pkg_dir\$nuget_file_name"
+Invoke-WebRequest -Uri $nuget_source -OutFile $nuget_destination
+dir $tmp_pkg_dir
+$nuget_exe = "$nuget_destination"
+
+# Download and Install OE Nuget Packages
+#
+$oe_version = "0.17.7"
+$oe_name = "open-enclave.OEHOSTVERIFY"
+$oe_nupkg_name = "$oe_name.$oe_version.nupkg"
+$oe_source = "https://github.com/openenclave/openenclave/releases/download/v$oe_version/$oe_nupkg_name"
+echo "OE Source = $oe_source"
+$oe_destination = "$tmp_pkg_dir\$oe_nupkg_name"
+Invoke-WebRequest -Uri $oe_source -OutFile $oe_destination
+dir $tmp_pkg_dir
+
+$oe_output_directory = "$tmp_pkg_dir\oe_installed_nupkg"
+$oe_nuget_args = @('install', $oe_name, '-Source', $tmp_pkg_dir, '-OutputDirectory', $oe_output_directory, '-ExcludeVersion')
+#TODO try to copy to the TMP
+$oe_path = "C:\$oe_name"
+$oe_xcopy_args = @('/i', '/y', '/e', "$oe_output_directory\$oe_name\openenclave", $oe_path)
+& $nuget_exe $oe_nuget_args
+xcopy $oe_xcopy_args
+dir $oe_path
+
+# Download and Install MS Azure DCAP Nuget Packages
+#
+$msdcap_version = "1.10.0"
+$msdcap_name = "Microsoft.Azure.DCAP"
+$msdcap_nupkg_name = "$msdcap_name.$msdcap_version.nupkg"
+$msdcap_source = "https://www.nuget.org/api/v2/package/Microsoft.Azure.DCAP/$msdcap_version"
+$msdcap_destination = "$tmp_pkg_dir\$msdcap_nupkg_name"
+Invoke-WebRequest -Uri $msdcap_source -OutFile $msdcap_destination
+dir $tmp_pkg_dir
+
+$msdcap_output_directory = "$tmp_pkg_dir\msdcap_installed_nupkg"
+$msdcap_nuget_args = @('install', $msdcap_name, '-Source', $tmp_pkg_dir, '-OutputDirectory', $msdcap_output_directory, '-ExcludeVersion')
+$msdcap_path = 'C:\azure_dcap'
+$msdcap_nuget_path = "$msdcap_path\$msdcap_name"
+& $nuget_exe $msdcap_nuget_args
+$msdcap_xcopy_args = @('/i', '/y', '/e', $msdcap_output_directory, $msdcap_path)
+xcopy $msdcap_xcopy_args
+# Install DCAP nuget
+cd "$msdcap_nuget_path\tools"
+& ".\InstallAzureDCAP.ps1" "$msdcap_nuget_path/DCAP_Components/build/lib/native/Libraries"
+dir $msdcap_path
+dir "$msdcap_nuget_path/DCAP_Components/build/lib/native/Libraries"
+[System.Environment]::SetEnvironmentVariable('AZDCAP_DEBUG_LOG_LEVEL','FATAL')
+
+# Build and Install vcpkg Dependencies
+#
+$vcpkg_dir="$cur_dir\vendors\vcpkg"
+
+cd $vcpkg_dir
+.\bootstrap-vcpkg.bat -disableMetrics
+.\vcpkg.exe integrate install
+.\vcpkg.exe install curl[openssl] openssl --triplet x64-windows
+
+$project_name = "jwt-verifier" 
+$project_dir="$cur_dir"
+
+cd $project_dir
+$project_out = "$cur_dir\tmp\out"
+If((Test-Path $project_out))
+{
+    Remove-Item $project_out -Force -Recurse
+}
+New-Item -ItemType Directory -Force -Path $project_out
+
+cd $project_out 
+
+cmake -DCMAKE_PREFIX_PATH="$oe_path\lib\openenclave\cmake" -DCMAKE_TOOLCHAIN_FILE="$vcpkg_dir/scripts/buildsystems/vcpkg.cmake" -DNUGET_PACKAGE_PATH="$msdcap_nuget_path" $project_dir
+
+$msbuild_exe=$Args[0]
+If($msbuild_exe -eq $null) {
+    $msbuild_exe = (Get-ChildItem -Recurse -Path "C:\Program Files (x86)\Microsoft Visual Studio\" -Include "msbuild.exe").fullname | Select -First 1
+}
+
+& $msbuild_exe "$project_name.sln"
+
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+echo ""
+
+cd .\Debug
+$project_exe_dir = Get-Location 
+echo "$project_name.exe's location: $project_exe_dir"
+dir $project_exe_dir 
+echo "Returning to $cur_dir..."
+
+cd $cur_dir
+


### PR DESCRIPTION
## Purpose
Adding [maa.jwt.verifier](https://github.com/kroshkina-ms/microsoft-azure-attestation/tree/master/maa.jwt.verifier)

JWT Verifier takes advantage of the Open Enclave SDK API call [oe_verify_attestation_certificate](https://openenclave.io/apidocs/v0.17/enclave_8h_a3b75c5638360adca181a0d945b45ad86.html#a3b75c5638360adca181a0d945b45ad86). See also https://openenclave.io/apidocs/v0.17/index.html .

This function performs a custom validation on the input certificate. This validation includes extracting an attestation evidence extension from the certificate before validating this evidence.

`jwt-verifier` builds and runs on Windows and Ubuntu Linux. The tool performs the following steps:
- [ ] Parses MAA JWT;
- [ ] Sends a request to MAA to get certificates;
- [ ] Deserialize JSON Web Keys and finds x.509 certificates for the key;
- [ ] Looks up for the MAA x509 extension;
- [ ] Verifies the certificate using oe_verify_attestation_certificate OpenEnclave API.

## Does this introduce a breaking change?
```
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Feature
```

## How to Test
*  Follow steps described in the `./maa.jwt.verifier/README.md`

## What to Check
Verify that the following are valid
* Build and setup process succeed
* MAA JWT attestation certificate is verified

## Other Information
* Added vcpkg for the Windows build of `jwt-verifier` 
* Added new folder `./maa.jwt.verifier`
